### PR TITLE
feat: Allow disabling auth of debug APIs using an env var

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -365,6 +365,9 @@ var (
 	EnableUnsafeAdminEndpoints = env.Register("UNSAFE_ENABLE_ADMIN_ENDPOINTS", false,
 		"If this is set to true, dangerous admin endpoints will be exposed on the debug interface. Not recommended for production.").Get()
 
+	DebugAuth = env.RegisterBoolVar("DEBUG_AUTH", true,
+		"If this is set to false, the debug interface will allow all anonymous request from any remote host, which is not recommended for production").Get()
+
 	XDSAuth = env.Register("XDS_AUTH", true,
 		"If true, will authenticate XDS clients.").Get()
 

--- a/pilot/pkg/xds/debug.go
+++ b/pilot/pkg/xds/debug.go
@@ -219,9 +219,12 @@ func (s *DiscoveryServer) addDebugHandler(mux *http.ServeMux, internalMux *http.
 	if internalMux != nil {
 		internalMux.HandleFunc(path, handler)
 	}
-
+	handlerFunc := http.HandlerFunc(handler)
+	if features.DebugAuth {
+		handlerFunc = s.allowAuthenticatedOrLocalhost(handlerFunc)
+	}
 	// Add handler with auth; this is expose on an HTTP server
-	mux.HandleFunc(path, s.allowAuthenticatedOrLocalhost(http.HandlerFunc(handler)))
+	mux.HandleFunc(path, handlerFunc)
 }
 
 func (s *DiscoveryServer) allowAuthenticatedOrLocalhost(next http.Handler) http.HandlerFunc {


### PR DESCRIPTION
Allow disabling auth of debug APIs using an env var.

Reference: https://github.com/alibaba/higress/blob/v1.4.2/istio/1.12/patches/istio/20230618-debug-api-anonymous.patch