### PR TITLE
fix: Fix the apt repo not signed error during building process

### DIFF
--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -39,11 +39,11 @@ ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version
 ARG TARGETARCH
 COPY ${TARGETARCH:-amd64}/pilot-agent /usr/local/bin/pilot-agent
 
-RUN apt-get update && \
-  apt-get install --no-install-recommends -y \
+RUN apt-get update --allow-unauthenticated && \
+  apt-get install --no-install-recommends -y --allow-unauthenticated \
   logrotate \
   cron \
-  && apt-get upgrade -y \
+  && apt-get upgrade -y --allow-unauthenticated \
   && apt-get clean
 
 # Latest releases available at https://github.com/aptible/supercronic/releases


### PR DESCRIPTION
Fix the apt repo not signed error during building process

![e6ef459a373c1c21315c8153ea7ab379](https://github.com/user-attachments/assets/50de9069-2b73-4b3f-bdd6-923042d38be5)