### PR TITLE
fix inclusionRegexps not working

### DIFF
--- a/tools/packaging/common/higress_envoy_bootstrap.json
+++ b/tools/packaging/common/higress_envoy_bootstrap.json
@@ -115,18 +115,41 @@
       }
     ],
     "stats_matcher": {
-      "exclusion_list": {
+      "inclusion_list": {
         "patterns": [
           {
-            "prefix": "vhost"
+          "prefix": "reporter="
+          },
+          {{- if .metadata_discovery }}
+          {
+          "prefix": "workload_discovery"
+          },
+          {{- end }}
+          {{- range $a, $s := .inclusionPrefix }}
+          {
+          "prefix": "{{$s}}"
+          },
+          {{- end }}
+          {{- range $a, $s := .inclusionSuffix }}
+          {
+          "suffix": "{{$s}}"
+          },
+          {{- end }}
+          {{- range $a, $s := .inclusionRegexps }}
+          {
+          "safe_regex": {"regex":"{{js $s}}"}
+          },
+          {{- end }}
+          {
+          "prefix": "component"
           },
           {
-            "safe_regex": {"regex": "^http.*\\.rds\\..*", "google_re2":{}}
+          "prefix": "istio"
           }
         ]
       }
     }
-  },  
+  },
   "admin": {
     "access_log": [
       {


### PR DESCRIPTION
**Please provide a description of this PR:**
higress_envoy_bootstrap.json里的stats_matcher是exclusion_list，导致inclusionRegexps配置项不生效</br>

To solve this problem
https://github.com/alibaba/higress/discussions/1935#discussioncomment-12563825

**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**


- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [X] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
