### PR TITLE
fix: change mcp-server.so to golang-filter.so

### DIFF
--- a/pilot/docker/Dockerfile.proxyv2
+++ b/pilot/docker/Dockerfile.proxyv2
@@ -34,7 +34,7 @@ ARG TARGETARCH
 COPY ${TARGETARCH:-amd64}/${SIDECAR} /usr/local/bin/${SIDECAR}
 
 # Install MCP server Golang Filter
-COPY ${TARGETARCH:-amd64}/mcp-server_${TARGETARCH:-amd64}.so /var/lib/istio/envoy/mcp-server.so
+COPY ${TARGETARCH:-amd64}/golang-filter_${TARGETARCH:-amd64}.so /var/lib/istio/envoy/golang-filter.so
 
 # Environment variable indicating the exact proxy sha - for debugging or version-specific configs
 ENV ISTIO_META_ISTIO_PROXY_SHA $proxy_version

--- a/tools/docker.yaml
+++ b/tools/docker.yaml
@@ -36,7 +36,7 @@ images:
   - tools/packaging/common/higress_envoy_bootstrap_lite.json
   - tools/packaging/common/higress_envoy_bootstrap.json
   - ${TARGET_OUT_LINUX}/${RELEASE_MODE}/${SIDECAR}
-  - /home/package/mcp-server_${TARGET_ARCH}.so
+  - /home/package/golang-filter_${TARGET_ARCH}.so
   targets:
   - ${TARGET_OUT_LINUX}/pilot-agent
 - name: pilot


### PR DESCRIPTION
**Please provide a description of this PR:**
change mcp-server.so to golang-filter.so


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
