### PR TITLE
Add the destination key for rds cache to resolve the issue of it not taking effect when enabling consistent hashing without modifying resources such as virtualService.

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/route.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/route.go
@@ -1500,6 +1500,16 @@ func hashForService(push *model.PushContext,
 	return consistentHash, mergedDR
 }
 
+// Added by higress
+func HashForVirtualService(push *model.PushContext,
+	node *model.Proxy,
+	virtualService config.Config,
+) (DestinationHashMap, []*model.ConsolidatedDestRule) {
+	return hashForVirtualService(push, node, virtualService)
+}
+
+// End added by higress
+
 func hashForVirtualService(push *model.PushContext,
 	node *model.Proxy,
 	virtualService config.Config,


### PR DESCRIPTION


**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
