### PR TITLE
Allow Higress to be deployed in kube-system

### DIFF
--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller.go
@@ -103,7 +103,7 @@ func NewNamespaceController(kubeClient kube.Client, caBundleWatcher *keycertbund
 
 	c.namespaces = kclient.New[*v1.Namespace](kubeClient)
 	// kube-system is not skipped to enable deploying higress in that namespace
-	c.ignoredNamespaces = c.ignoredNamespaces.Copy().Delete(constants.KubeSystemNamespace)
+	c.ignoredNamespaces = inject.IgnoredNamespaces.Copy().Delete(constants.KubeSystemNamespace)
 	c.configmaps.AddEventHandler(controllers.FilteredObjectSpecHandler(c.queue.AddObject, func(o controllers.Object) bool {
 		// Add by ingress
 		if o.GetNamespace() != podNs {
@@ -111,7 +111,7 @@ func NewNamespaceController(kubeClient kube.Client, caBundleWatcher *keycertbund
 		}
 		// End add by ingress
 		// skip special kubernetes system namespaces
-		return !inject.IgnoredNamespaces.Contains(o.GetNamespace())
+		return !c.ignoredNamespaces.Contains(o.GetNamespace())
 	}))
 
 	if c.DiscoveryNamespacesFilter != nil {

--- a/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/namespacecontroller_test.go
@@ -76,7 +76,8 @@ func TestNamespaceController(t *testing.T) {
 	deleteConfigMap(t, client.Kube(), "foo")
 	expectConfigMap(t, nc.configmaps, CACertNamespaceConfigMap, "foo", newData)
 
-	for _, namespace := range inject.IgnoredNamespaces.UnsortedList() {
+	ignoredNamespaces := inject.IgnoredNamespaces.Copy().Delete(constants.KubeSystemNamespace)
+	for _, namespace := range ignoredNamespaces.UnsortedList() {
 		// Create namespace in ignored list, make sure its not created
 		createNamespace(t, client.Kube(), namespace, newData)
 		// Configmap in that namespace should not do anything either


### PR DESCRIPTION
**Please provide a description of this PR:**
Refer to https://github.com/istio/istio/pull/49261
Solve the problem of higgres not being able to correctly create the higgres-ca-root-cert configmap when deployed in kube-system(https://github.com/alibaba/higress/issues/2543)


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
