### PR TITLE
Fix XDS deadlock caused by HTTP2 flow control

### DIFF
--- a/pilot/pkg/xds/ads.go
+++ b/pilot/pkg/xds/ads.go
@@ -34,6 +34,7 @@ import (
 	"istio.io/istio/pilot/pkg/networking/util"
 	labelutil "istio.io/istio/pilot/pkg/serviceregistry/util/label"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pkg/channels"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/env"
@@ -101,8 +102,16 @@ type Connection struct {
 	stop chan struct{}
 
 	// reqChan is used to receive discovery requests for this connection.
-	reqChan      chan *discovery.DiscoveryRequest
-	deltaReqChan chan *discovery.DeltaDiscoveryRequest
+	// Using unbounded channel to prevent deadlock caused by HTTP2 flow control.
+	// The gRPC system produces a natural looping of Recv and Send. Due to backpressure
+	// introduced by gRPC natively (that is, Send() can only send so much data without
+	// being Recv'd before it starts blocking), along with the backpressure provided by
+	// buffered channels, we have a risk of deadlock where both client and server are
+	// trying to Send, but both are blocked by gRPC backpressure until Recv() is called.
+	// However, Recv can fail to be called by Send being blocked.
+	// See https://github.com/istio/istio/issues/39209 for more information.
+	reqChan      *channels.Unbounded[*discovery.DiscoveryRequest]
+	deltaReqChan *channels.Unbounded[*discovery.DeltaDiscoveryRequest]
 
 	// errorChan is used to process error during discovery request processing.
 	errorChan chan error
@@ -122,7 +131,7 @@ func newConnection(peerAddr string, stream DiscoveryStream) *Connection {
 		pushChannel: make(chan *Event),
 		initialized: make(chan struct{}),
 		stop:        make(chan struct{}),
-		reqChan:     make(chan *discovery.DiscoveryRequest, 1),
+		reqChan:     channels.NewUnbounded[*discovery.DiscoveryRequest](),
 		errorChan:   make(chan error, 1),
 		peerAddr:    peerAddr,
 		connectedAt: time.Now(),
@@ -133,7 +142,7 @@ func newConnection(peerAddr string, stream DiscoveryStream) *Connection {
 func (s *DiscoveryServer) receive(con *Connection, identities []string) {
 	defer func() {
 		close(con.errorChan)
-		close(con.reqChan)
+		// Note: Unbounded channel does not need to be closed
 		// Close the initialized channel, if its not already closed, to prevent blocking the stream.
 		select {
 		case <-con.initialized:
@@ -175,11 +184,14 @@ func (s *DiscoveryServer) receive(con *Connection, identities []string) {
 			log.Infof("ADS: new connection for node:%s", con.conID)
 		}
 
+		// Put never blocks - requests are buffered in the unbounded channel
+		con.reqChan.Put(req)
+		// Check if the stream is done
 		select {
-		case con.reqChan <- req:
 		case <-con.stream.Context().Done():
 			log.Infof("ADS: %q %s terminated with stream closed", con.peerAddr, con.conID)
 			return
+		default:
 		}
 	}
 }
@@ -309,17 +321,16 @@ func (s *DiscoveryServer) Stream(stream DiscoveryStream) error {
 		// For requests, these are higher priority (client may be blocked on startup until these are done)
 		// and often very cheap to handle (simple ACK), so we check it first.
 		select {
-		case req, ok := <-con.reqChan:
-			if ok {
-				if err := s.processRequest(req, con); err != nil {
-					return err
-				}
-			} else {
-				// Remote side closed connection or error processing the request.
-				return <-con.errorChan
+		case req := <-con.reqChan.Get():
+			if err := s.processRequest(req, con); err != nil {
+				return err
 			}
+			con.reqChan.Load()
 		case <-con.stop:
 			return nil
+		case err := <-con.errorChan:
+			// Remote side closed connection or error processing the request.
+			return err
 		default:
 		}
 		// If there wasn't already a request, poll for requests and pushes. Note: if we have a huge
@@ -327,15 +338,11 @@ func (s *DiscoveryServer) Stream(stream DiscoveryStream) error {
 		// however, requests will be handled ~2x as much as pushes. This ensures a wave of requests
 		// cannot completely starve pushes. However, this scenario is unlikely.
 		select {
-		case req, ok := <-con.reqChan:
-			if ok {
-				if err := s.processRequest(req, con); err != nil {
-					return err
-				}
-			} else {
-				// Remote side closed connection or error processing the request.
-				return <-con.errorChan
+		case req := <-con.reqChan.Get():
+			if err := s.processRequest(req, con); err != nil {
+				return err
 			}
+			con.reqChan.Load()
 		case pushEv := <-con.pushChannel:
 			err := s.pushConnection(con, pushEv)
 			pushEv.done()
@@ -344,6 +351,9 @@ func (s *DiscoveryServer) Stream(stream DiscoveryStream) error {
 			}
 		case <-con.stop:
 			return nil
+		case err := <-con.errorChan:
+			// Remote side closed connection or error processing the request.
+			return err
 		}
 	}
 }

--- a/pilot/pkg/xds/delta.go
+++ b/pilot/pkg/xds/delta.go
@@ -31,6 +31,7 @@ import (
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/networking/util"
 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+	"istio.io/istio/pkg/channels"
 	istiolog "istio.io/istio/pkg/log"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
@@ -110,17 +111,16 @@ func (s *DiscoveryServer) StreamDeltas(stream DeltaDiscoveryStream) error {
 		// For requests, these are higher priority (client may be blocked on startup until these are done)
 		// and often very cheap to handle (simple ACK), so we check it first.
 		select {
-		case req, ok := <-con.deltaReqChan:
-			if ok {
-				if err := s.processDeltaRequest(req, con); err != nil {
-					return err
-				}
-			} else {
-				// Remote side closed connection or error processing the request.
-				return <-con.errorChan
+		case req := <-con.deltaReqChan.Get():
+			if err := s.processDeltaRequest(req, con); err != nil {
+				return err
 			}
+			con.deltaReqChan.Load()
 		case <-con.stop:
 			return nil
+		case err := <-con.errorChan:
+			// Remote side closed connection or error processing the request.
+			return err
 		default:
 		}
 		// If there wasn't already a request, poll for requests and pushes. Note: if we have a huge
@@ -128,15 +128,11 @@ func (s *DiscoveryServer) StreamDeltas(stream DeltaDiscoveryStream) error {
 		// however, requests will be handled ~2x as much as pushes. This ensures a wave of requests
 		// cannot completely starve pushes. However, this scenario is unlikely.
 		select {
-		case req, ok := <-con.deltaReqChan:
-			if ok {
-				if err := s.processDeltaRequest(req, con); err != nil {
-					return err
-				}
-			} else {
-				// Remote side closed connection or error processing the request.
-				return <-con.errorChan
+		case req := <-con.deltaReqChan.Get():
+			if err := s.processDeltaRequest(req, con); err != nil {
+				return err
 			}
+			con.deltaReqChan.Load()
 		case pushEv := <-con.pushChannel:
 			err := s.pushConnectionDelta(con, pushEv)
 			pushEv.done()
@@ -145,6 +141,9 @@ func (s *DiscoveryServer) StreamDeltas(stream DeltaDiscoveryStream) error {
 			}
 		case <-con.stop:
 			return nil
+		case err := <-con.errorChan:
+			// Remote side closed connection or error processing the request.
+			return err
 		}
 	}
 }
@@ -187,7 +186,7 @@ func (s *DiscoveryServer) pushConnectionDelta(con *Connection, pushEv *Event) er
 
 func (s *DiscoveryServer) receiveDelta(con *Connection, identities []string) {
 	defer func() {
-		close(con.deltaReqChan)
+		// Note: Unbounded channel does not need to be closed
 		close(con.errorChan)
 		// Close the initialized channel, if its not already closed, to prevent blocking the stream
 		select {
@@ -229,11 +228,14 @@ func (s *DiscoveryServer) receiveDelta(con *Connection, identities []string) {
 			deltaLog.Infof("ADS: new delta connection for node:%s", con.conID)
 		}
 
+		// Put never blocks - requests are buffered in the unbounded channel
+		con.deltaReqChan.Put(req)
+		// Check if the stream is done
 		select {
-		case con.deltaReqChan <- req:
 		case <-con.deltaStream.Context().Done():
 			deltaLog.Infof("ADS: %q %s terminated with stream closed", con.peerAddr, con.conID)
 			return
+		default:
 		}
 	}
 }
@@ -576,7 +578,7 @@ func newDeltaConnection(peerAddr string, stream DeltaDiscoveryStream) *Connectio
 		peerAddr:     peerAddr,
 		connectedAt:  time.Now(),
 		deltaStream:  stream,
-		deltaReqChan: make(chan *discovery.DeltaDiscoveryRequest, 1),
+		deltaReqChan: channels.NewUnbounded[*discovery.DeltaDiscoveryRequest](),
 		errorChan:    make(chan error, 1),
 	}
 }


### PR DESCRIPTION
Replace reqChan and deltaReqChan in Connection with channels.Unbounded to prevent deadlock caused by HTTP2 flow control:

1. When pushXds triggers HTTP2 flow control on large responses, the Stream method will no longer be blocked
2. The Put() method in receive never blocks, ensuring continuous reception of client requests
3. Client ACK requests can be received normally, avoiding bidirectional deadlock

This follows the same solution used in xds_proxy.go. See https://github.com/istio/istio/issues/39209 for more details.

Co-developed-by: Cursor <noreply@cursor.com>

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch ADS and Delta XDS request channels to unbounded queues and update receive/processing loops to avoid gRPC HTTP/2 flow-control deadlocks.
> 
> - **XDS server (ADS/Delta)**:
>   - **Channels**:
>     - Replace `reqChan` and `deltaReqChan` bounded channels with `channels.Unbounded[*DiscoveryRequest]` and `channels.Unbounded[*DeltaDiscoveryRequest]`.
>     - Do not close unbounded channels on teardown; still close `errorChan`.
>   - **Receive loops** (`receive`, `receiveDelta`):
>     - Use non-blocking `Put` to enqueue requests; add stream context check.
>   - **Processing loops** (`Stream`, `StreamDeltas`):
>     - Read via `Get()` and call `Load()` after handling; add explicit `errorChan` cases.
>   - **Constructors**:
>     - Initialize unbounded channels in `newConnection` and `newDeltaConnection`.
>   - **Imports**:
>     - Add `istio.io/istio/pkg/channels`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23dae1c5881548fbc2267f15405e4feecac2d64e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->