### PR TITLE
fix: prevent stale ECDS version overwriting during slow wasm image pull

### DIFF
--- a/pkg/istio-agent/xds_proxy.go
+++ b/pkg/istio-agent/xds_proxy.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -108,6 +110,9 @@ type XdsProxy struct {
 	ecdsLastNonce         atomic.String
 	downstreamGrpcOptions []grpc.ServerOption
 	istiodSAN             string
+	// Added by ingress
+	lastEcdsPushVersionInfo string
+	// End added by ingress
 }
 
 var proxyLog = log.RegisterScope("xdsproxy", "XDS Proxy in Istio Agent")
@@ -513,6 +518,9 @@ func (p *XdsProxy) handleUpstreamResponse(con *ProxyConnection) {
 			case model.ExtensionConfigurationType:
 				if features.WasmRemoteLoadConversion {
 					// If Wasm remote load conversion feature is enabled, rewrite and send.
+					// Added by ingress
+					p.lastEcdsPushVersionInfo = resp.VersionInfo
+					// End added by ingress
 					go p.rewriteAndForward(con, resp, func(resp *discovery.DiscoveryResponse) {
 						// Forward the response using the thread of `handleUpstreamResponse`
 						// to prevent concurrent access to forwardToEnvoy
@@ -529,7 +537,22 @@ func (p *XdsProxy) handleUpstreamResponse(con *ProxyConnection) {
 				forwardToEnvoy(con, resp)
 			}
 		case resp := <-forwardEnvoyCh:
-			forwardToEnvoy(con, resp)
+			// Modified by ingress
+			if !versionAfter(resp.VersionInfo, p.lastEcdsPushVersionInfo) {
+				err := fmt.Sprintf("received invalid ECDS version %s, lastest version %s", resp.VersionInfo, p.lastEcdsPushVersionInfo)
+				proxyLog.Info(err)
+				con.sendRequest(&discovery.DiscoveryRequest{
+					VersionInfo:   p.ecdsLastAckVersion.Load(),
+					TypeUrl:       model.ExtensionConfigurationType,
+					ResponseNonce: resp.Nonce,
+					ErrorDetail: &google_rpc.Status{
+						Message: err,
+					},
+				})
+			} else {
+				forwardToEnvoy(con, resp)
+			}
+			// End modified by ingress
 		case <-con.stopChan:
 			return
 		}
@@ -550,6 +573,7 @@ func (p *XdsProxy) rewriteAndForward(con *ProxyConnection, resp *discovery.Disco
 		})
 		return
 	}
+
 	proxyLog.Debugf("forward ECDS resources %+v", resp.Resources)
 	forward(resp)
 }
@@ -693,3 +717,39 @@ func downstreamErr(con *ProxyConnection, err error) {
 	case <-con.stopChan:
 	}
 }
+
+// Added by ingress
+func versionAfter(a, b string) bool {
+	if a == "" || b == "" || a == b {
+		return true
+	}
+	parts1 := strings.SplitN(a, "/", 2)
+	parts2 := strings.SplitN(b, "/", 2)
+
+	t1, err1 := time.Parse(time.RFC3339, parts1[0])
+	t2, err2 := time.Parse(time.RFC3339, parts2[0])
+
+	if err1 != nil || err2 != nil {
+		proxyLog.Errorf("Error parsing ecds version info times %v|%v", err1, err2)
+		return true
+	}
+
+	if t1.After(t2) {
+		return true
+	} else if t1.Before(t2) {
+		return false
+	}
+
+	num1, _ := strconv.Atoi(parts1[1])
+	num2, _ := strconv.Atoi(parts2[1])
+
+	if num1 < num2 {
+		return false
+	} else if num1 > num2 {
+		return true
+	}
+
+	return true
+}
+
+// End added by ingress

--- a/pkg/istio-agent/xds_proxy_test.go
+++ b/pkg/istio-agent/xds_proxy_test.go
@@ -611,3 +611,85 @@ func setupDownstreamConnectionUDS(t test.Failer, path string) *grpc.ClientConn {
 func setupDownstreamConnection(t *testing.T, proxy *XdsProxy) *grpc.ClientConn {
 	return setupDownstreamConnectionUDS(t, proxy.xdsUdsPath)
 }
+
+// Added by ingress
+func TestVersionAfter(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        string
+		b        string
+		expected bool
+	}{
+		{
+			name:     "both empty",
+			a:        "",
+			b:        "",
+			expected: true,
+		},
+		{
+			name:     "a empty",
+			a:        "",
+			b:        "2024-11-13T10:00:00Z/1",
+			expected: true,
+		},
+		{
+			name:     "b empty",
+			a:        "2024-11-13T10:00:00Z/1",
+			b:        "",
+			expected: true,
+		},
+		{
+			name:     "equal versions",
+			a:        "2024-11-13T10:00:00Z/1",
+			b:        "2024-11-13T10:00:00Z/1",
+			expected: true,
+		},
+		{
+			name:     "a has later time",
+			a:        "2024-11-13T11:00:00Z/1",
+			b:        "2024-11-13T10:00:00Z/1",
+			expected: true,
+		},
+		{
+			name:     "a has earlier time",
+			a:        "2024-11-13T09:00:00Z/1",
+			b:        "2024-11-13T10:00:00Z/1",
+			expected: false,
+		},
+		{
+			name:     "same time a has higher sequence",
+			a:        "2024-11-13T10:00:00Z/2",
+			b:        "2024-11-13T10:00:00Z/1",
+			expected: true,
+		},
+		{
+			name:     "same time a has lower sequence",
+			a:        "2024-11-13T10:00:00Z/1",
+			b:        "2024-11-13T10:00:00Z/2",
+			expected: false,
+		},
+		{
+			name:     "same time same sequence",
+			a:        "2024-11-13T10:00:00Z/1",
+			b:        "2024-11-13T10:00:00Z/1",
+			expected: true,
+		},
+		{
+			name:     "invalid time format returns true",
+			a:        "invalid/1",
+			b:        "2024-11-13T10:00:00Z/1",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := versionAfter(tt.a, tt.b)
+			if result != tt.expected {
+				t.Errorf("versionAfter(%q, %q) = %v, want %v", tt.a, tt.b, result, tt.expected)
+			}
+		})
+	}
+}
+
+// End added by ingress


### PR DESCRIPTION
## Summary
- When wasm image pulling is slow, a newer ECDS push may arrive before the previous rewrite completes. Without version checking, the older rewritten response could overwrite the newer one.
- Added `lastEcdsPushVersionInfo` field and `versionAfter` helper to compare ECDS versions by timestamp and sequence number.
- In the `forwardEnvoyCh` path, stale ECDS responses are now NACKed instead of being forwarded to Envoy.

## Test plan
- [x] Added `TestVersionAfter` unit test covering: empty values, equal versions, time comparison, sequence comparison, invalid format fallback
- [x] `go test ./pkg/istio-agent/ -run TestVersionAfter` passes
- [x] `go build ./pkg/istio-agent/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)