### PR TITLE
fix: propagate WasmPlugin failStrategy to envoy fail_open

### DIFF
--- a/pilot/pkg/model/extensions.go
+++ b/pilot/pkg/model/extensions.go
@@ -167,22 +167,14 @@ func (p *WasmPluginWrapper) buildPluginConfig(proxy *Proxy) *wasmextensions.Plug
 		Vm:            buildVMConfig(datasource, p.ResourceVersion, plugin),
 	}
 
-	// todo: wait go-control-plane to support
-	// FailOpen is deprecated in 1.25, remove this once v1.25 is EOL.
-	//if proxy.VersionGreaterOrEqual(&IstioVersion{Major: 1, Minor: 25, Patch: 0}) {
-	//	switch plugin.FailStrategy {
-	//	case extensions.FailStrategy_FAIL_OPEN:
-	//		wasmConfig.FailurePolicy = wasmextensions.FailurePolicy_FAIL_OPEN
-	//	case extensions.FailStrategy_FAIL_CLOSE:
-	//		wasmConfig.FailurePolicy = wasmextensions.FailurePolicy_FAIL_CLOSED
-	//	case extensions.FailStrategy_FAIL_RELOAD:
-	//		wasmConfig.FailurePolicy = wasmextensions.FailurePolicy_FAIL_RELOAD
-	//	}
-	//	// TODO: support more failure policies
-	//} else {
-	//	// nolint: staticcheck // FailOpen deprecated in 1.25
-	//	wasmConfig.FailOpen = plugin.FailStrategy == extensions.FailStrategy_FAIL_OPEN
-	//}
+	// Use the legacy fail_open bool instead of the new failure_policy enum:
+	// proxy-wasm-cpp-host's CHECK_FAIL macro only honors PluginBase::fail_open_, which is
+	// populated from config.fail_open(). A failure_policy=FAIL_OPEN alone would not take
+	// effect on mid-stream VM failures (e.g. wasm OOM during streaming response body).
+	// Setting only fail_open also avoids envoy's "only one of fail_open or failure_policy
+	// can be set" validation.
+	// nolint: staticcheck // fail_open is marked deprecated upstream but still honored
+	wasmConfig.FailOpen = plugin.FailStrategy == extensions.FailStrategy_FAIL_OPEN
 
 	return wasmConfig
 }


### PR DESCRIPTION
## Summary

- WasmPlugin's `failStrategy: FAIL_OPEN` was silently ignored: `buildPluginConfig` had the entire FailStrategy → envoy mapping commented out (waiting for go-control-plane to expose `FailurePolicy`), so the generated `wasm.PluginConfig` left both `fail_open` and `failure_policy` unset. Envoy treats unspecified as `FAIL_CLOSED`, producing 503 + `response_code_details=wasm_fail_stream` whenever a wasm VM failed.
- Fix: set the legacy `fail_open` bool from `FailStrategy`. Chosen over the new `FailurePolicy` enum because:
  1. proxy-wasm-cpp-host's `CHECK_FAIL` macro on mid-stream VM failures (e.g. OOM during a streaming response) only consults `PluginBase::fail_open_`, which is populated from `config.fail_open()`. A `failure_policy=FAIL_OPEN` alone would not cover that path.
  2. envoy enforces mutual exclusion between `fail_open` and `failure_policy` (`only one of fail_open or failure_policy can be set`).
- Restores parity with the istio-1.19 fork branch (commit `adfa27bbc9`), which already maps `FailStrategy → FailOpen`.

Refs higress-group/higress#3814.

## Test plan

- [x] `go test ./pilot/pkg/model -run TestFailStrategy -v` (close + open subtests both PASS)
- [x] `go build ./pilot/pkg/model/`
- [x] Manual: deploy a WasmPlugin with `failStrategy: FAIL_OPEN`, force the VM into a failed state (e.g. trigger ai-statistics OOM on a streaming response), confirm the request no longer returns 503 `wasm_fail_stream`.

## Not covered by this PR

- `FAIL_RELOAD` is still not propagated — it can't be expressed via the legacy bool. Wiring that up requires either bumping go-control-plane and addressing the dual-field mutex in envoy, or patching proxy-wasm-cpp-host's `CHECK_FAIL` to honor `failure_policy_` directly.
- The ai-statistics plugin itself still grows wasm heap unboundedly across a streaming LLM response — FAIL_OPEN avoids the 503 but does not fix the underlying memory leak.