### PR TITLE
Restore VERIFY_CERTIFICATE_AT_CLIENT compatibility flag

### DIFF
--- a/pilot/pkg/features/pilot.go
+++ b/pilot/pkg/features/pilot.go
@@ -213,6 +213,11 @@ var (
 	EnableRouteCollapse = env.Register("PILOT_ENABLE_ROUTE_COLLAPSE_OPTIMIZATION", true,
 		"If true, Pilot will merge virtual hosts with the same routes into a single virtual host, as an optimization.").Get()
 
+	// Add by Higress: keep Istio 1.19-compatible TLS verification behavior by default.
+	VerifyCertAtClient = env.Register("VERIFY_CERTIFICATE_AT_CLIENT", false,
+		"If enabled, certificates received by the proxy will be verified against the OS CA certificate bundle.").Get()
+	// End added by Higress.
+
 	MulticlusterHeadlessEnabled = env.Register("ENABLE_MULTICLUSTER_HEADLESS", true,
 		"If true, the DNS name table for a headless service will resolve to same-network endpoints in any cluster.").Get()
 

--- a/pilot/pkg/networking/core/cluster_tls.go
+++ b/pilot/pkg/networking/core/cluster_tls.go
@@ -36,7 +36,6 @@ import (
 	xdsfilters "istio.io/istio/pilot/pkg/xds/filters"
 	"istio.io/istio/pkg/log"
 	pm "istio.io/istio/pkg/model"
-	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/security"
 	"istio.io/istio/pkg/wellknown"
 )
@@ -205,9 +204,15 @@ func constructUpstreamTLS(opts *buildClusterOpts, tls *networking.ClientTLSSetti
 		// These are certs being mounted from within the pod and specified in Destination Rules.
 		// Rather than reading directly in Envoy, which does not support rotation, we will
 		// serve them over SDS by reading the files.
-		res := security.SdsCertificateConfig{
-			CaCertificatePath: ptr.NonEmptyOrDefault(tls.CaCertificates, "system"),
+		// Modified by Higress: restore Istio 1.19 VERIFY_CERTIFICATE_AT_CLIENT fallback without mutating shared TLS settings.
+		caCertificatePath := tls.CaCertificates
+		if features.VerifyCertAtClient && caCertificatePath == "" {
+			caCertificatePath = "system"
 		}
+		res := security.SdsCertificateConfig{
+			CaCertificatePath: caCertificatePath,
+		}
+		// End modified by Higress.
 		// If CredentialName is not set fallback to file based approach
 		if mutual {
 			if tls.ClientCertificate == "" || tls.PrivateKey == "" {
@@ -272,7 +277,7 @@ func applyTLSDefaults(tlsContext *tlsv3.UpstreamTlsContext, tlsDefaults *v1alpha
 }
 
 // Set auto_sni if sni field is not explicitly set in DR.
-// Set auto_san_validation if there is no explicit SubjectAltNames specified in DR.
+// Set auto_san_validation if VerifyCertAtClient is enabled and there is no explicit SubjectAltNames specified in DR.
 func setAutoSniAndAutoSanValidation(mc *clusterWrapper, tls *networking.ClientTLSSettings) {
 	if mc == nil {
 		return
@@ -283,9 +288,11 @@ func setAutoSniAndAutoSanValidation(mc *clusterWrapper, tls *networking.ClientTL
 	if len(tls.Sni) == 0 {
 		setAutoSni = true
 	}
-	if setAutoSni && len(tls.SubjectAltNames) == 0 && !tls.GetInsecureSkipVerify().GetValue() {
+	// Modified by Higress: keep auto SAN validation tied to VERIFY_CERTIFICATE_AT_CLIENT.
+	if features.VerifyCertAtClient && setAutoSni && len(tls.SubjectAltNames) == 0 && !tls.GetInsecureSkipVerify().GetValue() {
 		setAutoSanValidation = true
 	}
+	// End modified by Higress.
 
 	if setAutoSni || setAutoSanValidation {
 		if mc.httpProtocolOptions == nil {


### PR DESCRIPTION
## Summary

- Restore the `VERIFY_CERTIFICATE_AT_CLIENT` feature flag with a Higress-compatible default of `false`.
- When the flag is disabled, empty `caCertificates` keeps the Istio 1.19 behavior and does not fall back to the system CA bundle.
- When the flag is enabled, empty `caCertificates` uses `file-root:system`, matching newer upstream Istio behavior without modifying shared TLS objects.
- Keep auto SAN validation tied to `VERIFY_CERTIFICATE_AT_CLIENT`, consistent with the previous upstream implementation.

## Motivation

Higress is upgrading this Istio fork from the 1.19 behavior, where empty `caCertificates` did not configure root certificate verification by default. Newer upstream Istio treats empty `caCertificates` as system-root verification, which can break existing internal HTTPS backends that use self-signed certificates, private CAs, incomplete chains, or mismatched SAN/SNI.

This keeps the default compatible while still allowing users to opt in to the newer verification behavior with `VERIFY_CERTIFICATE_AT_CLIENT=true`.

## Tests

- `go test ./pilot/pkg/networking/core -run 'TestBuildUpstreamClusterTLSContext|TestApplyDestinationRuleOSCACert' -count=1`
